### PR TITLE
Redirect all traffic to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^1.1.0",
+    "grunt-sass": "^2.0.0",
     "heroku-ssl-redirect": "0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "assemble": "^0.4.42",
     "assemble-contrib-permalinks": "^0.3.6",
+    "express": "^4.13.3",
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^3.0.0",
     "grunt-cli": "^0.1.13",
@@ -29,6 +30,6 @@
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-sass": "^1.1.0",
-    "express": "^4.13.3"
+    "heroku-ssl-redirect": "0.0.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,8 +1,11 @@
 var express = require('express');
+var sslRedirect = require('heroku-ssl-redirect');
 var app = express();
 
 app.set('port', (process.env.PORT || 5000));
 
+// enable ssl redirect
+app.use(sslRedirect());
 app.use(express.static('dist'));
 
 var server = app.listen(app.get('port'), () => {


### PR DESCRIPTION
Update the express code to redirect all traffic to https when in production mode.

Also, fixed a problem with CircleCI builds because of an outdated `grunt-sass` package.