### PR TITLE
update: thoughtbot apprenticeship url and location

### DIFF
--- a/source/data/data.yml
+++ b/source/data/data.yml
@@ -113,33 +113,33 @@ apprenticeships:
       company: thoughtbot
       anchor: thoughtbot
       duration: 3 months
-      location: ["Boston, MA", "San Francisco, CA"]
+      location: ["Austin, TX", "Boston, MA", "London, UK", "New York, NY", "Raleigh, NC", "San Francisco, CA"]
       category: design
       cta: learn more and apply
       company_url: https://thoughtbot.com/
-      apply_url: https://thoughtbot.com/playbook/our-company/apprenticeship
+      apply_url: https://tbot.io/apprenticeship
       summary: |
         We want those ready to advance to the next level in their career. The program is ideal for designers with experience with graphical design for the web or iOS as well as HTML and CSS.
   - apprenticeship:
       company: thoughtbot
       anchor: thoughtbot
       duration: 3 months
-      location: ["Boston, MA", "San Francisco, CA"]
+      location: ["Austin, TX", "Boston, MA", "London, UK", "New York, NY", "Raleigh, NC", "San Francisco, CA"]
       category: development
       cta: learn more and apply
       company_url: https://thoughtbot.com/
-      apply_url: https://thoughtbot.com/playbook/our-company/apprenticeship
+      apply_url: https://tbot.io/apprenticeship
       summary: |
         We want those ready to advance to the next level in their career. The program is ideal for intermediate developers and designers looking to build upon an already-strong foundation.
   - apprenticeship:
       company: thoughtbot
       anchor: thoughtbot
       duration: 3 months
-      location: ["Boston, MA", "San Francisco, CA"]
+      location: ["Austin, TX", "Boston, MA", "London, UK", "New York, NY", "Raleigh, NC", "San Francisco, CA"]
       category: mobile
       cta: learn more and apply
       company_url: https://thoughtbot.com/
-      apply_url: https://thoughtbot.com/playbook/our-company/apprenticeship
+      apply_url: https://tbot.io/apprenticeship
       summary: |
         We want those ready to advance to the next level in their career. The program is ideal for developers at an intermediate level with Objective-C or Swift.
 


### PR DESCRIPTION
Update the Thoughtbot apprenticeship url and locations for all 3 apprenticeships

How to QA:

- Pull down this branch
- Run `grunt build`
- Then run `heroku local`
- Go to `http://localhost:5000/` and check that the locations and urls are updated for every Thoughtbot apprenticeship

<img width="1046" alt="screen shot 2019-02-20 at 3 23 33 pm" src="https://user-images.githubusercontent.com/3081483/53122014-826fc000-3523-11e9-98c5-2e5a35c1744c.png">
