### PR TITLE
Fix heading skipped on about/submit page

### DIFF
--- a/source/templates/partials/_content__header--inside.hbs
+++ b/source/templates/partials/_content__header--inside.hbs
@@ -1,3 +1,3 @@
-<header class="content__header content__header--inside">
-  <h1>{{ header }}</h1>
-</header> 
+<div class="content__header content__header--inside">
+  <h2>{{ header }}</h2>
+</div>

--- a/source/templates/partials/_header.hbs
+++ b/source/templates/partials/_header.hbs
@@ -1,5 +1,7 @@
 <header class="wrapper header">
-  <object type="image/svg+xml" data="{{ assets }}/img/apprenticeships--animated.svg" class="header--is-animated">
-    <img src="{{ assets }}/img/apprenticeships.png" alt="Apprenticeships" class="apprenticeships-fallback" />
-  </object>
+  <h1 aria-label="Apprenticeships">
+    <object type="image/svg+xml" data="{{ assets }}/img/apprenticeships--animated.svg" class="header--is-animated">
+      <img src="{{ assets }}/img/apprenticeships.png" alt="Apprenticeships" class="apprenticeships-fallback" />
+    </object>
+  </h1>
 </header>


### PR DESCRIPTION
- Changed second heading on about & submit page to h2 tag 
- Added  h1 tag  to the Header logo