### PR TITLE
Fix:  Home Page A11y

### DIFF
--- a/source/scss/modules/_categories.scss
+++ b/source/scss/modules/_categories.scss
@@ -44,7 +44,7 @@
     }
     a {
       color: $c--white;
-      background: $c--shady-lady;
+      background: $c--shady-lady-dark;
       -webkit-font-smoothing: antialiased;
       position: relative;
       @include rem( padding, .5 );

--- a/source/scss/utilities/_config.scss
+++ b/source/scss/utilities/_config.scss
@@ -22,4 +22,5 @@ $c--mine-shaft: #3A3A3A;
 $c--white: #FFF;
 $c--black: #000;
 $c--shady-lady: #A6A6A6;
+$c--shady-lady-dark: #767676;
 $c--rust: #B72A0B;

--- a/source/templates/partials/_header.hbs
+++ b/source/templates/partials/_header.hbs
@@ -1,6 +1,6 @@
 <header class="wrapper header">
   <h1 aria-label="Apprenticeships">
-    <object type="image/svg+xml" data="{{ assets }}/img/apprenticeships--animated.svg" class="header--is-animated">
+    <object aria-label="Apprenticeships" type="image/svg+xml" data="{{ assets }}/img/apprenticeships--animated.svg" class="header--is-animated">
       <img src="{{ assets }}/img/apprenticeships.png" alt="Apprenticeships" class="apprenticeships-fallback" />
     </object>
   </h1>


### PR DESCRIPTION
Fix Home Page A11y issues

**Desktop** errors:
- Failing contrast on 'Report a problem' will be fixed in [APPAT-31](https://sparkbox.atlassian.net/browse/APPAT-31)
- `<object>` element in Apprenticeship header is missing alt aria-label text
<img width="334" alt="Screen Shot 2022-02-03 at 11 28 21 AM" src="https://user-images.githubusercontent.com/34315878/152392658-5d3b1421-0c76-4a2c-9a2d-4ac36268e8cd.png">

**Mobile** errors:
- Failing contrast on apprentice category item backgrounds
<img width="336" alt="Screen Shot 2022-02-03 at 11 21 28 AM" src="https://user-images.githubusercontent.com/34315878/152392909-0b23209f-5fa0-4359-8b3e-abb62f451784.png">
 

**After chages rating:**
<img width="356" alt="Screen Shot 2022-02-03 at 12 15 28 PM" src="https://user-images.githubusercontent.com/34315878/152394013-036a934a-9974-409f-aa10-a9cac966f8dd.png">