### PR TITLE
test: intercept form submission

### DIFF
--- a/cypress/integration/formSpec.js
+++ b/cypress/integration/formSpec.js
@@ -70,6 +70,10 @@ describe('Apprenticeship submit form', () => {
 
     describe('Should submit a successful form', () => {
         it('should submit a successful aprrenticeship form', () => {
+            cy.intercept('POST', '/thank-you/', (req) => {
+              req.redirect('/thank-you', 301)
+            }).as('thankYou');
+
             cy.get('[data-cy=form_compensation-field]')
             .should('be.visible')
             .check('Yes');


### PR DESCRIPTION
Looks like we're getting actual form submissions come through when the Cypress tests run against the PR deployments in Netlify. We can see this in the `#sparkbox-com` channel on Slack. This PR uses [`cy.intercept`](https://docs.cypress.io/api/commands/intercept) to intercept the form post and stub the response by issuing a redirect to the `/thank-you` page. This allows the test to exercise the form submission without actually submitting it. 

### Validation
1. In theory, when I create this PR, we should _not_ see a form submission notification in `#sparkbox-com` after the tests run in CI.
1. When running Cypress locally, we should now see output that the request is being intercepted. At the start of the test, we'll see the route defined:
<img width="434" alt="Screen Shot 2022-02-24 at 5 50 04 PM" src="https://user-images.githubusercontent.com/565751/155736452-6571ac3e-2dbe-4b53-9590-d1e1a7cb1672.png">

Then, when the form is submitted in the test, we should see that it's using the intercept:
<img width="413" alt="Screen Shot 2022-02-24 at 5 50 18 PM" src="https://user-images.githubusercontent.com/565751/155736466-acccd6c4-070e-42d5-92b4-a4abe4d307d0.png">

: